### PR TITLE
Add AccountTrade, DepositLog, ExchangeInfo and WithdrawalLog to Binance Spot API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CryptoAPIs"
 uuid = "5e3d4798-c815-4641-85e1-deed530626d3"
-version = "0.6.0"
+version = "0.7.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/docs/src/pages/Binance.md
+++ b/docs/src/pages/Binance.md
@@ -12,11 +12,15 @@ CryptoAPIs.Binance.Spot.public_client
 ```
 
 ```@docs
-CryptoAPIs.Binance.Spot.candle
+CryptoAPIs.Binance.Spot.account_trade
 CryptoAPIs.Binance.Spot.avg_price
+CryptoAPIs.Binance.Spot.candle
+CryptoAPIs.Binance.Spot.coin_information
+CryptoAPIs.Binance.Spot.deposit_log
+CryptoAPIs.Binance.Spot.exchange_info
 CryptoAPIs.Binance.Spot.order_book
 CryptoAPIs.Binance.Spot.ticker
-CryptoAPIs.Binance.Spot.coin_information
+CryptoAPIs.Binance.Spot.withdrawal_log
 ```
 
 ## USDMFutures

--- a/examples/Binance/Spot.jl
+++ b/examples/Binance/Spot.jl
@@ -15,6 +15,8 @@ Binance.Spot.candle(;
     limit = 4,
 )
 
+Binance.Spot.exchange_info()
+
 Binance.Spot.order_book(; symbol = "BTCUSDT", limit = 10)
 
 Binance.Spot.ticker()
@@ -27,4 +29,13 @@ binance_client = BinanceClient(;
     secret_key = ENV["BINANCE_SECRET_KEY"],
 )
 
+Binance.Spot.account_trade(
+    binance_client;
+    symbol = "BTCUSDT",
+)
+
 Binance.Spot.coin_information(binance_client)
+
+Binance.Spot.deposit_log(binance_client)
+
+Binance.Spot.withdrawal_log(binance_client)

--- a/src/Binance/Spot/API/AccountTrade.jl
+++ b/src/Binance/Spot/API/AccountTrade.jl
@@ -85,22 +85,22 @@ to_pretty_json(result.result)
 
 ```json
 [
-    {
-        "symbol": "BNBBTC",
-        "id": 28457,
-        "orderId": 100234,
-        "orderListId": -1,
-        "price": "4.00000100",
-        "qty": "12.00000000",
-        "quoteQty": "48.000012",
-        "commission": "10.10000000",
-        "commissionAsset": "BNB",
-        "time": 1499865549590,
-        "isBuyer": true,
-        "isMaker": false,
-        "isBestMatch": true
-    },
-    ...
+  {
+    "symbol": "BNBBTC",
+    "id": 28457,
+    "orderId": 100234,
+    "orderListId": -1,
+    "price": "4.00000100",
+    "qty": "12.00000000",
+    "quoteQty": "48.000012",
+    "commission": "10.10000000",
+    "commissionAsset": "BNB",
+    "time": 1499865549590,
+    "isBuyer": true,
+    "isMaker": false,
+    "isBestMatch": true
+  },
+  ...
 ]
 ```
 """

--- a/src/Binance/Spot/API/AccountTrade.jl
+++ b/src/Binance/Spot/API/AccountTrade.jl
@@ -86,19 +86,19 @@ to_pretty_json(result.result)
 ```json
 [
   {
-    "symbol": "BNBBTC",
-    "id": 28457,
-    "orderId": 100234,
-    "orderListId": -1,
-    "price": "4.00000100",
-    "qty": "12.00000000",
-    "quoteQty": "48.000012",
-    "commission": "10.10000000",
-    "commissionAsset": "BNB",
-    "time": 1499865549590,
-    "isBuyer": true,
-    "isMaker": false,
-    "isBestMatch": true
+    "symbol":"BNBBTC",
+    "id":28457,
+    "orderId":100234,
+    "orderListId":-1,
+    "price":4.00000100,
+    "qty":12.00000000,
+    "quoteQty":48.000012,
+    "commission":10.10000000,
+    "commissionAsset":"BNB",
+    "time":"2017-07-12T13:19:09",
+    "isBuyer":true,
+    "isMaker":false,
+    "isBestMatch":true
   },
   ...
 ]

--- a/src/Binance/Spot/API/AccountTrade.jl
+++ b/src/Binance/Spot/API/AccountTrade.jl
@@ -1,0 +1,115 @@
+module AccountTrade
+
+export AccountTradeQuery,
+    AccountTradeData,
+    account_trade
+
+using Serde
+using Dates, NanoDates, TimeZones
+
+using CryptoAPIs.Binance
+using CryptoAPIs: Maybe, APIsRequest
+
+Base.@kwdef mutable struct AccountTradeQuery <: BinancePrivateQuery
+    symbol::String
+    orderId::Maybe{Int64} = nothing
+    startTime::Maybe{DateTime} = nothing
+    endTime::Maybe{DateTime} = nothing
+    fromId::Maybe{Int64} = nothing
+    limit::Maybe{Int64} = 1000
+
+    recvWindow::Maybe{Int64} = nothing
+    timestamp::Maybe{DateTime} = nothing
+    signature::Maybe{String} = nothing
+end
+
+struct AccountTradeData <: BinanceData
+    symbol::String
+    id::Int64
+    orderId::Int64
+    orderListId::Int64
+    price::Float64
+    qty::Float64
+    quoteQty::Float64
+    commission::Float64
+    commissionAsset::String
+    time::NanoDate
+    isBuyer::Bool
+    isMaker::Bool
+    isBestMatch::Bool
+end
+
+"""
+    account_trade(client::BinanceClient, query::AccountTradeQuery)
+    account_trade(client::BinanceClient; kw...)
+
+Get trades for a specific account and symbol.
+
+[`GET api/v3/myTrades`](https://binance-docs.github.io/apidocs/spot/en/#account-trade-list-user_data)
+
+## Parameters:
+
+| Parameter  | Type     | Required | Description |
+|:-----------|:---------|:---------|:------------|
+| symbol     | String   | true     |             |
+| orderId    | Int64    | false    |             |
+| startTime  | DateTime | false    |             |
+| endTime    | DateTime | false    |             |
+| fromId     | Int64    | false    |             |
+| limit      | Int64    | false    |             |
+| recvWindow | Int64    | false    |             |
+| signature  | String   | false    |             |
+| timestamp  | DateTime | false    |             |
+
+## Code samples:
+
+```julia
+using Serde
+using CryptoAPIs.Binance
+
+binance_client = BinanceClient(;
+    base_url = "https://api.binance.com",
+    public_key = ENV["BINANCE_PUBLIC_KEY"],
+    secret_key = ENV["BINANCE_SECRET_KEY"],
+)
+
+result = Binance.Spot.account_trade(
+    binance_client;
+    symbol = "BTCUSDT",
+)
+
+to_pretty_json(result.result)
+```
+
+## Result:
+
+```json
+[
+    {
+        "symbol": "BNBBTC",
+        "id": 28457,
+        "orderId": 100234,
+        "orderListId": -1,
+        "price": "4.00000100",
+        "qty": "12.00000000",
+        "quoteQty": "48.000012",
+        "commission": "10.10000000",
+        "commissionAsset": "BNB",
+        "time": 1499865549590,
+        "isBuyer": true,
+        "isMaker": false,
+        "isBestMatch": true
+    },
+    ...
+]
+```
+"""
+function account_trade(client::BinanceClient, query::AccountTradeQuery)
+    return APIsRequest{Vector{AccountTradeData}}("GET", "api/v3/myTrades", query)(client)
+end
+
+function account_trade(client::BinanceClient; kw...)
+    return account_trade(client, AccountTradeQuery(; kw...))
+end
+
+end

--- a/src/Binance/Spot/API/AccountTrade.jl
+++ b/src/Binance/Spot/API/AccountTrade.jl
@@ -49,17 +49,17 @@ Get trades for a specific account and symbol.
 
 ## Parameters:
 
-| Parameter  | Type     | Required | Description |
-|:-----------|:---------|:---------|:------------|
-| symbol     | String   | true     |             |
-| orderId    | Int64    | false    |             |
-| startTime  | DateTime | false    |             |
-| endTime    | DateTime | false    |             |
-| fromId     | Int64    | false    |             |
-| limit      | Int64    | false    |             |
-| recvWindow | Int64    | false    |             |
-| signature  | String   | false    |             |
-| timestamp  | DateTime | false    |             |
+| Parameter  | Type     | Required | Description   |
+|:-----------|:---------|:---------|:--------------|
+| symbol     | String   | true     |               |
+| orderId    | Int64    | false    |               |
+| startTime  | DateTime | false    |               |
+| endTime    | DateTime | false    |               |
+| fromId     | Int64    | false    |               |
+| limit      | Int64    | false    | Default: 1000 |
+| recvWindow | Int64    | false    |               |
+| signature  | String   | false    |               |
+| timestamp  | DateTime | false    |               |
 
 ## Code samples:
 

--- a/src/Binance/Spot/API/Candle.jl
+++ b/src/Binance/Spot/API/Candle.jl
@@ -88,20 +88,20 @@ to_pretty_json(result.result)
 
 ```json
 [
-    {
-        "openTime":"2018-04-01T00:00:00",
-        "openPrice":0.25551,
-        "highPrice":0.3866,
-        "lowPrice":0.23983,
-        "closePrice":0.34145,
-        "volume":1.17451580874e9,
-        "closeTime":"2018-04-30T23:59:59.999000064",
-        "quoteAssetVolume":3.597636214561159e8,
-        "tradesNumber":759135,
-        "takerBuyBaseAssetVolume":5.556192707e8,
-        "takerBuyQuoteAssetVolume":1.706766832130686e8
-    },
-    ...
+  {
+    "openTime":"2018-04-01T00:00:00",
+    "openPrice":0.25551,
+    "highPrice":0.3866,
+    "lowPrice":0.23983,
+    "closePrice":0.34145,
+    "volume":1.17451580874e9,
+    "closeTime":"2018-04-30T23:59:59.999000064",
+    "quoteAssetVolume":3.597636214561159e8,
+    "tradesNumber":759135,
+    "takerBuyBaseAssetVolume":5.556192707e8,
+    "takerBuyQuoteAssetVolume":1.706766832130686e8
+  },
+  ...
 ]
 ```
 """

--- a/src/Binance/Spot/API/DepositLog.jl
+++ b/src/Binance/Spot/API/DepositLog.jl
@@ -96,25 +96,25 @@ to_pretty_json(result.result)
 
 ```json
 [
-    {
-        "id": "b6ae22b3aa844210a7041aee7589627c",
-        "amount": "8.91000000",
-        "transactionFee": "0.004",
-        "coin": "USDT",
-        "status": 6,
-        "address": "0x94df8b352de7f46f64b01d3666bf6e936e44ce60",
-        "txId": "0xb5ef8c13b968a406cc62a93a8bd80f9e9a906ef1b3fcf20a2e48573c17659268",
-        "applyTime": "2019-10-12 11:12:02",
-        "network": "ETH",
-        "transferType": 0,
-        "withdrawOrderId": "WITHDRAWtest123",
-        "info": "The address is not valid. Please confirm with the recipient",
-        "confirmNo":3,
-        "walletType": 1,
-        "txKey": "",
-        "completeTime": "2023-03-23 16:52:41"
-    },
-    ...
+  {
+    "id": "b6ae22b3aa844210a7041aee7589627c",
+    "amount": "8.91000000",
+    "transactionFee": "0.004",
+    "coin": "USDT",
+    "status": 6,
+    "address": "0x94df8b352de7f46f64b01d3666bf6e936e44ce60",
+    "txId": "0xb5ef8c13b968a406cc62a93a8bd80f9e9a906ef1b3fcf20a2e48573c17659268",
+    "applyTime": "2019-10-12 11:12:02",
+    "network": "ETH",
+    "transferType": 0,
+    "withdrawOrderId": "WITHDRAWtest123",
+    "info": "The address is not valid. Please confirm with the recipient",
+    "confirmNo":3,
+    "walletType": 1,
+    "txKey": "",
+    "completeTime": "2023-03-23 16:52:41"
+  },
+  ...
 ]
 ```
 """

--- a/src/Binance/Spot/API/DepositLog.jl
+++ b/src/Binance/Spot/API/DepositLog.jl
@@ -97,22 +97,19 @@ to_pretty_json(result.result)
 ```json
 [
   {
-    "id": "b6ae22b3aa844210a7041aee7589627c",
-    "amount": "8.91000000",
-    "transactionFee": "0.004",
-    "coin": "USDT",
-    "status": 6,
-    "address": "0x94df8b352de7f46f64b01d3666bf6e936e44ce60",
-    "txId": "0xb5ef8c13b968a406cc62a93a8bd80f9e9a906ef1b3fcf20a2e48573c17659268",
-    "applyTime": "2019-10-12 11:12:02",
-    "network": "ETH",
-    "transferType": 0,
-    "withdrawOrderId": "WITHDRAWtest123",
-    "info": "The address is not valid. Please confirm with the recipient",
-    "confirmNo":3,
-    "walletType": 1,
-    "txKey": "",
-    "completeTime": "2023-03-23 16:52:41"
+    "id":769800519366885376,
+    "amount":0.001,
+    "coin":"BNB",
+    "network":"BNB",
+    "status":0,
+    "address":"bnb136ns6lfw4zs5hg4n85vdthaad7hq5m4gtkgf23",
+    "addressTag":"101764890",
+    "txId":"98A3EA560C6B3336D348B6C83F0F95ECE4F1F5919E94BD006E5BF3BF264FACFC",
+    "insertTime":"2022-08-26T05:52:26",
+    "transferType":0,
+    "confirmTimes":"1/1",
+    "unlockConfirm":0,
+    "walletType":0
   },
   ...
 ]

--- a/src/Binance/Spot/API/DepositLog.jl
+++ b/src/Binance/Spot/API/DepositLog.jl
@@ -62,18 +62,18 @@ Fetch deposit history.
 
 ## Parameters:
 
-| Parameter  | Type          | Required | Description |
-|:-----------|:--------------|:---------|:------------|
-| coin       | String        | false    |             |
-| endTime    | DateTime      | false    |             |
-| limit      | Int64         | false    |             |
-| offset     | Int64         | false    |             |
-| startTime  | DateTime      | false    |             |
-| status     | DepositStatus | false    |             |
-| txId       | String        | false    |             |
-| recvWindow | Int64         | false    |             |
-| timestamp  | DateTime      | false    |             |
-| signature  | String        | false    |             |
+| Parameter  | Type          | Required | Description   |
+|:-----------|:--------------|:---------|:--------------|
+| coin       | String        | false    |               |
+| endTime    | DateTime      | false    |               |
+| limit      | Int64         | false    | Default: 1000 |
+| offset     | Int64         | false    |               |
+| startTime  | DateTime      | false    |               |
+| status     | DepositStatus | false    |               |
+| txId       | String        | false    |               |
+| recvWindow | Int64         | false    |               |
+| timestamp  | DateTime      | false    |               |
+| signature  | String        | false    |               |
 
 ## Code samples:
 

--- a/src/Binance/Spot/API/DepositLog.jl
+++ b/src/Binance/Spot/API/DepositLog.jl
@@ -1,0 +1,129 @@
+module DepositLog
+
+export DepositLogQuery,
+    DepositLogData,
+    deposit_log
+
+using Serde
+using Dates, NanoDates, TimeZones
+
+using CryptoAPIs.Binance
+using CryptoAPIs: Maybe, APIsRequest
+
+@enum DepositStatus begin
+    PENDING = 0
+    SUCCESS = 1
+    CREDITED_BUT_CANNOT_WITHDRAW = 6
+    WRONG_DEPOSIT = 7
+    WAITING_USER_CONFIRM = 8
+end
+
+Base.@kwdef mutable struct DepositLogQuery <: BinancePrivateQuery
+    coin::Maybe{String} = nothing
+    endTime::Maybe{DateTime} = nothing
+    limit::Maybe{Int64} = 1000
+    offset::Maybe{Int64} = nothing
+    startTime::Maybe{DateTime} = nothing
+    status::Maybe{DepositStatus} = nothing
+    txId::Maybe{String} = nothing
+
+    recvWindow::Maybe{Int64} = nothing
+    timestamp::Maybe{DateTime} = nothing
+    signature::Maybe{String} = nothing
+end
+
+function Serde.SerQuery.ser_type(::Type{<:DepositLogQuery}, x::DepositStatus)::Int64
+    return Int64(x)
+end
+
+struct DepositLogData <: BinanceData
+    address::String
+    addressTag::String
+    amount::Float64
+    coin::String
+    confirmTimes::String
+    id::Int64
+    insertTime::NanoDate
+    network::String
+    status::DepositStatus
+    transferType::Int64
+    txId::Maybe{String}
+    unlockConfirm::Int64
+    walletType::Int64
+end
+
+"""
+    deposit_log(client::BinanceClient, query::DepositLogQuery)
+    deposit_log(client::BinanceClient; kw...)
+
+Fetch deposit history.
+
+[`GET sapi/v1/capital/withdraw/history`](https://binance-docs.github.io/apidocs/spot/en/#deposit-history-supporting-network-user_data)
+
+## Parameters:
+
+| Parameter  | Type          | Required | Description |
+|:-----------|:--------------|:---------|:------------|
+| coin       | String        | false    |             |
+| endTime    | DateTime      | false    |             |
+| limit      | Int64         | false    |             |
+| offset     | Int64         | false    |             |
+| startTime  | DateTime      | false    |             |
+| status     | DepositStatus | false    |             |
+| txId       | String        | false    |             |
+| recvWindow | Int64         | false    |             |
+| timestamp  | DateTime      | false    |             |
+| signature  | String        | false    |             |
+
+## Code samples:
+
+```julia
+using Serde
+using CryptoAPIs.Binance
+
+binance_client = BinanceClient(;
+    base_url = "https://api.binance.com",
+    public_key = ENV["BINANCE_PUBLIC_KEY"],
+    secret_key = ENV["BINANCE_SECRET_KEY"],
+)
+
+result = Binance.Spot.deposit_log(binance_client)
+
+to_pretty_json(result.result)
+```
+
+## Result:
+
+```json
+[
+    {
+        "id": "b6ae22b3aa844210a7041aee7589627c",
+        "amount": "8.91000000",
+        "transactionFee": "0.004",
+        "coin": "USDT",
+        "status": 6,
+        "address": "0x94df8b352de7f46f64b01d3666bf6e936e44ce60",
+        "txId": "0xb5ef8c13b968a406cc62a93a8bd80f9e9a906ef1b3fcf20a2e48573c17659268",
+        "applyTime": "2019-10-12 11:12:02",
+        "network": "ETH",
+        "transferType": 0,
+        "withdrawOrderId": "WITHDRAWtest123",
+        "info": "The address is not valid. Please confirm with the recipient",
+        "confirmNo":3,
+        "walletType": 1,
+        "txKey": "",
+        "completeTime": "2023-03-23 16:52:41"
+    },
+    ...
+]
+```
+"""
+function deposit_log(client::BinanceClient, query::DepositLogQuery)
+    return APIsRequest{Vector{DepositLogData}}("GET", "sapi/v1/capital/deposit/hisrec", query)(client)
+end
+
+function deposit_log(client::BinanceClient; kw...)
+    return deposit_log(client, DepositLogQuery(; kw...))
+end
+
+end

--- a/src/Binance/Spot/API/ExchangeInfo.jl
+++ b/src/Binance/Spot/API/ExchangeInfo.jl
@@ -114,7 +114,9 @@ Current exchange trading rules and symbol information.
 using Serde
 using CryptoAPIs.Binance
 
-result = Binance.Spot.exchange_info()
+result = Binance.Spot.exchange_info(;
+    symbol = "ADAUSDT"
+)
 
 to_pretty_json(result.result)
 ```
@@ -123,51 +125,86 @@ to_pretty_json(result.result)
 
 ```json
 {
-  "timezone": "UTC",
-  "serverTime": 1565246363776,
-  "rateLimits": [
-      {
-      }
-  ],
-  "exchangeFilters": [
-  ],
-  "symbols": [
+  "exchangeFilters":[],
+  "rateLimits":[
     {
-      "symbol": "ETHBTC",
-      "status": "TRADING",
-      "baseAsset": "ETH",
-      "baseAssetPrecision": 8,
-      "quoteAsset": "BTC",
-      "quotePrecision": 8,
-      "quoteAssetPrecision": 8,
-      "orderTypes": [
+      "limit":6000,
+      "rateLimitType":"REQUEST_WEIGHT",
+      "interval":"MINUTE",
+      "intervalNum":1
+    },
+    ...
+  ],
+  "serverTime":"2024-04-01T09:35:01.003000064",
+  "symbols":[
+    {
+      "allowTrailingStop":true,
+      "allowedSelfTradePreventionModes":[
+        "EXPIRE_TAKER",
+        "EXPIRE_MAKER",
+        "EXPIRE_BOTH"
+      ],
+      "baseAsset":"ADA",
+      "baseAssetPrecision":8,
+      "baseCommissionPrecision":8,
+      "cancelReplaceAllowed":true,
+      "defaultSelfTradePreventionMode":"EXPIRE_MAKER",
+      "filters":[
+        {
+          "applyToMarket":null,
+          "askMultiplierDown":null,
+          "askMultiplierUp":null,
+          "avgPriceMins":null,
+          "bidMultiplierDown":null,
+          "bidMultiplierUp":null,
+          "filterType":"PRICE_FILTER",
+          "limit":null,
+          "maxNumAlgoOrders":null,
+          "maxNumOrders":null,
+          "maxPosition":null,
+          "maxPrice":1000.0,
+          "maxQty":null,
+          "maxTrailingAboveDelta":null,
+          "maxTrailingBelowDelta":null,
+          "minNotional":null,
+          "minPrice":0.0001,
+          "minQty":null,
+          "minTrailingAboveDelta":null,
+          "minTrailingBelowDelta":null,
+          "multiplierDown":null,
+          "multiplierUp":null,
+          "stepSize":null,
+          "tickSize":0.0001
+        },
+        ...
+      ],
+      "icebergAllowed":true,
+      "isMarginTradingAllowed":true,
+      "isSpotTradingAllowed":true,
+      "ocoAllowed":true,
+      "orderTypes":[
         "LIMIT",
         "LIMIT_MAKER",
         "MARKET",
-        "STOP_LOSS",
         "STOP_LOSS_LIMIT",
-        "TAKE_PROFIT",
         "TAKE_PROFIT_LIMIT"
       ],
-      "icebergAllowed": true,
-      "ocoAllowed": true,
-      "quoteOrderQtyMarketAllowed": true,
-      "allowTrailingStop": false,
-      "cancelReplaceAllowed": false,
-      "isSpotTradingAllowed": true,
-      "isMarginTradingAllowed": true,
-      "filters": [
-      ],
-      "permissions": [
+      "permissions":[
         "SPOT",
-        "MARGIN"
+        "MARGIN",
+        "TRD_GRP_004",
+        ...
       ],
-      "defaultSelfTradePreventionMode": "NONE",
-      "allowedSelfTradePreventionModes": [
-        "NONE"
-      ]
+      "quoteAsset":"USDT",
+      "quoteAssetPrecision":8,
+      "quoteCommissionPrecision":8,
+      "quoteOrderQtyMarketAllowed":true,
+      "quotePrecision":8,
+      "status":"TRADING",
+      "symbol":"ADAUSDT"
     }
-  ]
+  ],
+  "timezone":"UTC"
 }
 ```
 """

--- a/src/Binance/Spot/API/ExchangeInfo.jl
+++ b/src/Binance/Spot/API/ExchangeInfo.jl
@@ -123,51 +123,51 @@ to_pretty_json(result.result)
 
 ```json
 {
-    "timezone": "UTC",
-    "serverTime": 1565246363776,
-    "rateLimits": [
-        {
-        }
-    ],
-    "exchangeFilters": [
-    ],
-    "symbols": [
-        {
-            "symbol": "ETHBTC",
-            "status": "TRADING",
-            "baseAsset": "ETH",
-            "baseAssetPrecision": 8,
-            "quoteAsset": "BTC",
-            "quotePrecision": 8,
-            "quoteAssetPrecision": 8,
-            "orderTypes": [
-                "LIMIT",
-                "LIMIT_MAKER",
-                "MARKET",
-                "STOP_LOSS",
-                "STOP_LOSS_LIMIT",
-                "TAKE_PROFIT",
-                "TAKE_PROFIT_LIMIT"
-            ],
-            "icebergAllowed": true,
-            "ocoAllowed": true,
-            "quoteOrderQtyMarketAllowed": true,
-            "allowTrailingStop": false,
-            "cancelReplaceAllowed": false,
-            "isSpotTradingAllowed": true,
-            "isMarginTradingAllowed": true,
-            "filters": [
-            ],
-            "permissions": [
-                "SPOT",
-                "MARGIN"
-            ],
-            "defaultSelfTradePreventionMode": "NONE",
-            "allowedSelfTradePreventionModes": [
-                "NONE"
-            ]
-        }
-    ]
+  "timezone": "UTC",
+  "serverTime": 1565246363776,
+  "rateLimits": [
+      {
+      }
+  ],
+  "exchangeFilters": [
+  ],
+  "symbols": [
+    {
+      "symbol": "ETHBTC",
+      "status": "TRADING",
+      "baseAsset": "ETH",
+      "baseAssetPrecision": 8,
+      "quoteAsset": "BTC",
+      "quotePrecision": 8,
+      "quoteAssetPrecision": 8,
+      "orderTypes": [
+        "LIMIT",
+        "LIMIT_MAKER",
+        "MARKET",
+        "STOP_LOSS",
+        "STOP_LOSS_LIMIT",
+        "TAKE_PROFIT",
+        "TAKE_PROFIT_LIMIT"
+      ],
+      "icebergAllowed": true,
+      "ocoAllowed": true,
+      "quoteOrderQtyMarketAllowed": true,
+      "allowTrailingStop": false,
+      "cancelReplaceAllowed": false,
+      "isSpotTradingAllowed": true,
+      "isMarginTradingAllowed": true,
+      "filters": [
+      ],
+      "permissions": [
+        "SPOT",
+        "MARGIN"
+      ],
+      "defaultSelfTradePreventionMode": "NONE",
+      "allowedSelfTradePreventionModes": [
+        "NONE"
+      ]
+    }
+  ]
 }
 ```
 """

--- a/src/Binance/Spot/API/ExchangeInfo.jl
+++ b/src/Binance/Spot/API/ExchangeInfo.jl
@@ -1,0 +1,182 @@
+module ExchangeInfo
+
+export ExchangeInfoQuery,
+    ExchangeInfoData,
+    exchange_info
+
+using Serde
+using Dates, NanoDates, TimeZones
+
+using CryptoAPIs.Binance
+using CryptoAPIs: Maybe, APIsRequest
+
+@enum Permission SPOT MARGIN LEVERAGED TRD_GRP_002 TRD_GRP_003 TRD_GRP_004 TRD_GRP_005 TRD_GRP_006 TRD_GRP_007
+
+Base.@kwdef struct ExchangeInfoQuery <: BinancePublicQuery
+    permissions::Maybe{Vector{Permission}} = nothing
+    symbol::Maybe{String} = nothing
+    symbols::Maybe{Vector{String}} = nothing
+end
+
+function Serde.SerQuery.ser_type(::Type{<:ExchangeInfoQuery}, x::Vector{String})::String
+    return "[\"" * join(x, "\",\"") * "\"]"
+end
+
+function Serde.SerQuery.ser_type(::Type{<:ExchangeInfoQuery}, x::Vector{Permission})::String
+    return "[\"" * join(x, "\",\"") * "\"]"
+end
+
+struct Filter <: BinanceData
+    applyToMarket::Maybe{Bool}
+    askMultiplierDown::Maybe{Float64}
+    askMultiplierUp::Maybe{Float64}
+    avgPriceMins::Maybe{Int64}
+    bidMultiplierDown::Maybe{Float64}
+    bidMultiplierUp::Maybe{Float64}
+    filterType::String
+    limit::Maybe{Int64}
+    maxNumAlgoOrders::Maybe{Int64}
+    maxNumOrders::Maybe{Int64}
+    maxPosition::Maybe{Float64}
+    maxPrice::Maybe{Float64}
+    maxQty::Maybe{Float64}
+    maxTrailingAboveDelta::Maybe{Int64}
+    maxTrailingBelowDelta::Maybe{Int64}
+    minNotional::Maybe{Float64}
+    minPrice::Maybe{Float64}
+    minQty::Maybe{Float64}
+    minTrailingAboveDelta::Maybe{Int64}
+    minTrailingBelowDelta::Maybe{Int64}
+    multiplierDown::Maybe{Float64}
+    multiplierUp::Maybe{Float64}
+    stepSize::Maybe{Float64}
+    tickSize::Maybe{Float64}
+end
+
+struct Ratelimit <: BinanceData
+    limit::Int64
+    rateLimitType::String
+    interval::String
+    intervalNum::Int64
+end
+
+struct Symbols <: BinanceData
+    allowTrailingStop::Bool
+    allowedSelfTradePreventionModes::Vector{String}
+    baseAsset::String
+    baseAssetPrecision::Int64
+    baseCommissionPrecision::Int64
+    cancelReplaceAllowed::Bool
+    defaultSelfTradePreventionMode::String
+    filters::Vector{Filter}
+    icebergAllowed::Bool
+    isMarginTradingAllowed::Bool
+    isSpotTradingAllowed::Bool
+    ocoAllowed::Bool
+    orderTypes::Vector{String}
+    permissions::Vector{Any}
+    quoteAsset::String
+    quoteAssetPrecision::Int64
+    quoteCommissionPrecision::Int64
+    quoteOrderQtyMarketAllowed::Bool
+    quotePrecision::Int64
+    status::String
+    symbol::String
+end
+
+struct ExchangeInfoData <: BinanceData
+    exchangeFilters::Vector{Any}
+    rateLimits::Vector{Ratelimit}
+    serverTime::NanoDate
+    symbols::Vector{Symbols}
+    timezone::String
+end
+
+"""
+    exchange_info(client::BinanceClient, query::ExchangeInfoQuery)
+    exchange_info(client::BinanceClient = Binance.Spot.public_client; kw...)
+
+Current exchange trading rules and symbol information.
+
+[`GET api/v3/exchangeInfo`](https://binance-docs.github.io/apidocs/spot/en/#exchange-information)
+
+## Parameters:
+
+| Parameter   | Type   | Required | Description |
+|:------------|:-------|:---------|:------------|
+| permissions | Vector | false    |             |
+| symbol      | String | false    |             |
+| symbols     | Vector | false    |             |
+
+## Code samples:
+
+```julia
+using Serde
+using CryptoAPIs.Binance
+
+result = Binance.Spot.exchange_info()
+
+to_pretty_json(result.result)
+```
+
+## Result:
+
+```json
+{
+    "timezone": "UTC",
+    "serverTime": 1565246363776,
+    "rateLimits": [
+        {
+        }
+    ],
+    "exchangeFilters": [
+    ],
+    "symbols": [
+        {
+            "symbol": "ETHBTC",
+            "status": "TRADING",
+            "baseAsset": "ETH",
+            "baseAssetPrecision": 8,
+            "quoteAsset": "BTC",
+            "quotePrecision": 8,
+            "quoteAssetPrecision": 8,
+            "orderTypes": [
+                "LIMIT",
+                "LIMIT_MAKER",
+                "MARKET",
+                "STOP_LOSS",
+                "STOP_LOSS_LIMIT",
+                "TAKE_PROFIT",
+                "TAKE_PROFIT_LIMIT"
+            ],
+            "icebergAllowed": true,
+            "ocoAllowed": true,
+            "quoteOrderQtyMarketAllowed": true,
+            "allowTrailingStop": false,
+            "cancelReplaceAllowed": false,
+            "isSpotTradingAllowed": true,
+            "isMarginTradingAllowed": true,
+            "filters": [
+            ],
+            "permissions": [
+                "SPOT",
+                "MARGIN"
+            ],
+            "defaultSelfTradePreventionMode": "NONE",
+            "allowedSelfTradePreventionModes": [
+                "NONE"
+            ]
+        }
+    ]
+}
+```
+"""
+function exchange_info(client::BinanceClient, query::ExchangeInfoQuery)
+    return APIsRequest{ExchangeInfoData}("GET", "api/v3/exchangeInfo", query)(client)
+end
+
+function exchange_info(client::BinanceClient = Binance.Spot.public_client; kw...)
+    return exchange_info(client, ExchangeInfoQuery(; kw...))
+end
+
+end

--- a/src/Binance/Spot/API/WithdrawalLog.jl
+++ b/src/Binance/Spot/API/WithdrawalLog.jl
@@ -101,22 +101,21 @@ to_pretty_json(result.result)
 ```json
 [
   {
-    "id": "b6ae22b3aa844210a7041aee7589627c",
-    "amount": "8.91000000",
-    "transactionFee": "0.004",
-    "coin": "USDT",
-    "status": 6,
-    "address": "0x94df8b352de7f46f64b01d3666bf6e936e44ce60",
-    "txId": "0xb5ef8c13b968a406cc62a93a8bd80f9e9a906ef1b3fcf20a2e48573c17659268"
-    "applyTime": "2019-10-12 11:12:02",
-    "network": "ETH",
-    "transferType": 0,
-    "withdrawOrderId": "WITHDRAWtest123",
-    "info": "The address is not valid. Please confirm with the recipient",
+    "id":"b6ae22b3aa844210a7041aee7589627c",
+    "amount":8.91000000,
+    "transactionFee":0.004,
+    "coin":"USDT",
+    "status":6,
+    "address":"0x94df8b352de7f46f64b01d3666bf6e936e44ce60",
+    "txId":"0xb5ef8c13b968a406cc62a93a8bd80f9e9a906ef1b3fcf20a2e48573c17659268"
+    "applyTime":"2019-10-12T11:12:02",
+    "network":"ETH",
+    "transferType":0,
+    "info":"",
     "confirmNo":3,
-    "walletType": 1,
-    "txKey": "",
-    "completeTime": "2023-03-23 16:52:41"
+    "walletType":1,
+    "txKey":"",
+    "completeTime":"2023-03-23T16:52:41"
   },
   ...
 ]

--- a/src/Binance/Spot/API/WithdrawalLog.jl
+++ b/src/Binance/Spot/API/WithdrawalLog.jl
@@ -66,18 +66,18 @@ Fetch withdraw history.
 
 ## Parameters:
 
-| Parameter       | Type           | Required | Description |
-|:----------------|:---------------|:---------|:------------|
-| coin            | String         | false    |             |
-| endTime         | DateTime       | false    |             |
-| limit           | Int64          | false    |             |
-| offset          | Int64          | false    |             |
-| startTime       | DateTime       | false    |             |
-| status          | WithdrawStatus | false    |             |
-| withdrawOrderId | String         | false    |             |
-| recvWindow      | Int64          | false    |             |
-| signature       | String         | false    |             |
-| timestamp       | DateTime       | false    |             |
+| Parameter       | Type           | Required | Description   |
+|:----------------|:---------------|:---------|:--------------|
+| coin            | String         | false    |               |
+| endTime         | DateTime       | false    |               |
+| limit           | Int64          | false    | Default: 1000 |
+| offset          | Int64          | false    |               |
+| startTime       | DateTime       | false    |               |
+| status          | WithdrawStatus | false    |               |
+| withdrawOrderId | String         | false    |               |
+| recvWindow      | Int64          | false    |               |
+| signature       | String         | false    |               |
+| timestamp       | DateTime       | false    |               |
 
 ## Code samples:
 

--- a/src/Binance/Spot/API/WithdrawalLog.jl
+++ b/src/Binance/Spot/API/WithdrawalLog.jl
@@ -100,25 +100,25 @@ to_pretty_json(result.result)
 
 ```json
 [
-    {
-        "id": "b6ae22b3aa844210a7041aee7589627c",
-        "amount": "8.91000000",
-        "transactionFee": "0.004",
-        "coin": "USDT",
-        "status": 6,
-        "address": "0x94df8b352de7f46f64b01d3666bf6e936e44ce60",
-        "txId": "0xb5ef8c13b968a406cc62a93a8bd80f9e9a906ef1b3fcf20a2e48573c17659268"
-        "applyTime": "2019-10-12 11:12:02",
-        "network": "ETH",
-        "transferType": 0,
-        "withdrawOrderId": "WITHDRAWtest123",
-        "info": "The address is not valid. Please confirm with the recipient",
-        "confirmNo":3,
-        "walletType": 1,
-        "txKey": "",
-        "completeTime": "2023-03-23 16:52:41"
-    },
-    ...
+  {
+    "id": "b6ae22b3aa844210a7041aee7589627c",
+    "amount": "8.91000000",
+    "transactionFee": "0.004",
+    "coin": "USDT",
+    "status": 6,
+    "address": "0x94df8b352de7f46f64b01d3666bf6e936e44ce60",
+    "txId": "0xb5ef8c13b968a406cc62a93a8bd80f9e9a906ef1b3fcf20a2e48573c17659268"
+    "applyTime": "2019-10-12 11:12:02",
+    "network": "ETH",
+    "transferType": 0,
+    "withdrawOrderId": "WITHDRAWtest123",
+    "info": "The address is not valid. Please confirm with the recipient",
+    "confirmNo":3,
+    "walletType": 1,
+    "txKey": "",
+    "completeTime": "2023-03-23 16:52:41"
+  },
+  ...
 ]
 ```
 """

--- a/src/Binance/Spot/API/WithdrawalLog.jl
+++ b/src/Binance/Spot/API/WithdrawalLog.jl
@@ -1,0 +1,133 @@
+module WithdrawalLog
+
+export WithdrawalLogQuery,
+    WithdrawalLogData,
+    withdrawal_log
+
+using Serde
+using Dates, NanoDates, TimeZones
+
+using CryptoAPIs.Binance
+using CryptoAPIs: Maybe, APIsRequest
+
+@enum WithdrawStatus begin
+    EMAIL_SENT = 0
+    CANCELLED = 1
+    AWAITING_APPROVAL = 2
+    REJECTED = 3
+    PROCESSING = 4
+    FAILURE = 5
+    COMPLETED = 6
+end
+
+Base.@kwdef mutable struct WithdrawalLogQuery <: BinancePrivateQuery
+    coin::Maybe{String} = nothing
+    endTime::Maybe{DateTime} = nothing
+    limit::Maybe{Int64} = 1000
+    offset::Maybe{Int64} = nothing
+    startTime::Maybe{DateTime} = nothing
+    status::Maybe{WithdrawStatus} = nothing
+    withdrawOrderId::Maybe{String} = nothing
+
+    recvWindow::Maybe{Int64} = nothing
+    timestamp::Maybe{DateTime} = nothing
+    signature::Maybe{String} = nothing
+end
+
+function Serde.SerQuery.ser_type(::Type{<:WithdrawalLogQuery}, x::WithdrawStatus)::Int64
+    return Int64(x)
+end
+
+struct WithdrawalLogData <: BinanceData
+    address::String
+    amount::Float64
+    applyTime::NanoDate
+    coin::String
+    confirmNo::Maybe{Int64}
+    id::String
+    info::String
+    network::String
+    status::WithdrawStatus
+    transactionFee::Float64
+    transferType::Int64
+    txId::Maybe{String}
+    txKey::Maybe{String}
+    walletType::Int64
+    completeTime::Maybe{NanoDate}
+end
+
+"""
+    withdrawal_log(client::BinanceClient, query::WithdrawalLogQuery)
+    withdrawal_log(client::BinanceClient; kw...)
+
+Fetch withdraw history.
+
+[`GET sapi/v1/capital/withdraw/history`](https://binance-docs.github.io/apidocs/spot/en/#withdraw-history-supporting-network-user_data)
+
+## Parameters:
+
+| Parameter       | Type           | Required | Description |
+|:----------------|:---------------|:---------|:------------|
+| coin            | String         | false    |             |
+| endTime         | DateTime       | false    |             |
+| limit           | Int64          | false    |             |
+| offset          | Int64          | false    |             |
+| startTime       | DateTime       | false    |             |
+| status          | WithdrawStatus | false    |             |
+| withdrawOrderId | String         | false    |             |
+| recvWindow      | Int64          | false    |             |
+| signature       | String         | false    |             |
+| timestamp       | DateTime       | false    |             |
+
+## Code samples:
+
+```julia
+using Serde
+using CryptoAPIs.Binance
+
+binance_client = BinanceClient(;
+    base_url = "https://api.binance.com",
+    public_key = ENV["BINANCE_PUBLIC_KEY"],
+    secret_key = ENV["BINANCE_SECRET_KEY"],
+)
+
+result = Binance.Spot.withdrawal_log(binance_client)
+
+to_pretty_json(result.result)
+```
+
+## Result:
+
+```json
+[
+    {
+        "id": "b6ae22b3aa844210a7041aee7589627c",
+        "amount": "8.91000000",
+        "transactionFee": "0.004",
+        "coin": "USDT",
+        "status": 6,
+        "address": "0x94df8b352de7f46f64b01d3666bf6e936e44ce60",
+        "txId": "0xb5ef8c13b968a406cc62a93a8bd80f9e9a906ef1b3fcf20a2e48573c17659268"
+        "applyTime": "2019-10-12 11:12:02",
+        "network": "ETH",
+        "transferType": 0,
+        "withdrawOrderId": "WITHDRAWtest123",
+        "info": "The address is not valid. Please confirm with the recipient",
+        "confirmNo":3,
+        "walletType": 1,
+        "txKey": "",
+        "completeTime": "2023-03-23 16:52:41"
+    },
+    ...
+]
+```
+"""
+function withdrawal_log(client::BinanceClient, query::WithdrawalLogQuery)
+    return APIsRequest{Vector{WithdrawalLogData}}("GET", "sapi/v1/capital/withdraw/history", query)(client)
+end
+
+function withdrawal_log(client::BinanceClient; kw...)
+    return withdrawal_log(client, WithdrawalLogQuery(; kw...))
+end
+
+end 

--- a/src/Binance/Spot/Spot.jl
+++ b/src/Binance/Spot/Spot.jl
@@ -8,6 +8,9 @@ using CryptoAPIs.Binance
 const public_client =
     BinanceClient(; base_url = "https://api.binance.com")
 
+include("API/AccountTrade.jl")
+using .AccountTrade
+
 include("API/AvgPrice.jl")
 using .AvgPrice
 
@@ -17,10 +20,19 @@ using .Candle
 include("API/CoinInformation.jl")
 using .CoinInformation
 
+include("API/DepositLog.jl")
+using .DepositLog
+
+include("API/ExchangeInfo.jl")
+using .ExchangeInfo
+
 include("API/OrderBook.jl")
 using .OrderBook
 
 include("API/Ticker.jl")
 using .Ticker
+
+include("API/WithdrawalLog.jl")
+using .WithdrawalLog
 
 end

--- a/src/Binance/USDMFutures/USDMFutures.jl
+++ b/src/Binance/USDMFutures/USDMFutures.jl
@@ -22,4 +22,5 @@ using .OrderBook
 
 include("API/Ticker.jl")
 using .Ticker
+
 end


### PR DESCRIPTION
Pull request contains new modules for Binance Spot API such as AccountTrade, DepositLog, ExchangeInfo and WithdrawalLog.

ExchangeInfo specified in https://github.com/bhftbootcamp/CryptoAPIs.jl/issues/2.

The following issue will be resolved with this PR:

closes https://github.com/bhftbootcamp/CryptoAPIs.jl/issues/2 - Extend Binance Spot API support.

### Pull request checklist

- [x] Did you bump the project version?
- [x] Did you add a description to the Pull Request?
- [ ] Did you add new tests?
- [x] Did you add reviewers?
