### PR TITLE
Add endpoints to Coinbase Spot API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CryptoAPIs"
 uuid = "5e3d4798-c815-4641-85e1-deed530626d3"
-version = "0.12.0"
+version = "0.13.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/docs/src/pages/Coinbase.md
+++ b/docs/src/pages/Coinbase.md
@@ -14,8 +14,8 @@ CryptoAPIs.Coinbase.Spot.public_client
 ```@docs
 CryptoAPIs.Coinbase.Spot.candle
 CryptoAPIs.Coinbase.Spot.currency
-CryptoAPIs.Coinbase.Spot.ticker
-CryptoAPIs.Coinbase.Spot.product
 CryptoAPIs.Coinbase.Spot.fee_estimate
+CryptoAPIs.Coinbase.Spot.product
 CryptoAPIs.Coinbase.Spot.product_stats
+CryptoAPIs.Coinbase.Spot.ticker
 ```

--- a/docs/src/pages/Coinbase.md
+++ b/docs/src/pages/Coinbase.md
@@ -16,4 +16,6 @@ CryptoAPIs.Coinbase.Spot.candle
 CryptoAPIs.Coinbase.Spot.currency
 CryptoAPIs.Coinbase.Spot.ticker
 CryptoAPIs.Coinbase.Spot.product
+CryptoAPIs.Coinbase.Spot.fee_estimate
+CryptoAPIs.Coinbase.Spot.product_stats
 ```

--- a/examples/Coinbase/Spot.jl
+++ b/examples/Coinbase/Spot.jl
@@ -14,7 +14,13 @@ CryptoAPIs.Coinbase.Spot.candle(;
 
 CryptoAPIs.Coinbase.Spot.currency()
 
-CryptoAPIs.Coinbase.Spot.fee_estimate()
+coinbase_client = CoinbaseClient(;
+    base_url = "https://api.exchange.coinbase.com",
+    public_key = ENV["COINBASE_PUBLIC_KEY"],
+    secret_key = ENV["COINBASE_SECRET_KEY"],
+)
+
+CryptoAPIs.Coinbase.Spot.fee_estimate(coinbase_client)
 
 CryptoAPIs.Coinbase.Spot.product_stats(; product_id = "BTC-USD")
 

--- a/examples/Coinbase/Spot.jl
+++ b/examples/Coinbase/Spot.jl
@@ -14,4 +14,8 @@ CryptoAPIs.Coinbase.Spot.candle(;
 
 CryptoAPIs.Coinbase.Spot.currency()
 
+CryptoAPIs.Coinbase.Spot.fee_estimate()
+
+CryptoAPIs.Coinbase.Spot.product_stats(; product_id = "BTC-USD")
+
 CryptoAPIs.Coinbase.Spot.ticker(; product_id = "BTC-USDT")

--- a/examples/Coinbase/Spot.jl
+++ b/examples/Coinbase/Spot.jl
@@ -18,6 +18,7 @@ coinbase_client = CoinbaseClient(;
     base_url = "https://api.exchange.coinbase.com",
     public_key = ENV["COINBASE_PUBLIC_KEY"],
     secret_key = ENV["COINBASE_SECRET_KEY"],
+    passphrase = ENV["COINBASE_PASSPHRASE"],
 )
 
 CryptoAPIs.Coinbase.Spot.fee_estimate(coinbase_client)

--- a/src/Coinbase/Coinbase.jl
+++ b/src/Coinbase/Coinbase.jl
@@ -75,7 +75,8 @@ end
 function CryptoAPIs.request_sign!(client::CoinbaseClient, query::Q, endpoint::String)::Q where {Q<:CoinbasePrivateQuery}
     query.timestamp = string(round(Int64, datetime2unix(Dates.now(UTC))))
     query.signature = nothing
-    message = join([query.timestamp, "GET", endpoint])
+    str_query = Serde.to_query(query)
+    message = join([query.timestamp, "GET", endpoint, str_query])
     query.signature = hexdigest("sha256", client.secret_key, message)
     return query
 end

--- a/src/Coinbase/Coinbase.jl
+++ b/src/Coinbase/Coinbase.jl
@@ -76,10 +76,10 @@ end
 function CryptoAPIs.request_sign!(client::CoinbaseClient, query::Q, endpoint::String)::Q where {Q<:CoinbasePrivateQuery}
     query.timestamp = string(round(Int64, datetime2unix(Dates.now(UTC))))
     query.signature = nothing
-    endpoint = "/" * endpoint
-    message = join([query.timestamp, "GET", endpoint])
-    decoded_secret_key = base64decode(client.secret_key)
-    query.signature = hexdigest("sha256", decoded_secret_key, message)
+    str_query = isempty(Serde.to_query(query)) ? "" : "?" * Serde.to_query(query)
+    endpoint = "/" * endpoint * str_query
+    message = join([query.timestamp, "GET", endpoint, ""])
+    query.signature = base64encode(digest("sha256", base64decode(client.secret_key), message))
     return query
 end
 

--- a/src/Coinbase/Coinbase.jl
+++ b/src/Coinbase/Coinbase.jl
@@ -76,9 +76,11 @@ function CryptoAPIs.request_sign!(client::CoinbaseClient, query::Q, endpoint::St
     query.timestamp = string(round(Int64, datetime2unix(Dates.now(UTC))))
     query.signature = nothing
     str_query = Serde.to_query(query)
-    endpoint = "/" * endpoint * "?"
+    if !isempty(str_query)
+        str_query = "?" * str_query
+    end
+    endpoint = "/" * endpoint
     message = join([query.timestamp, "GET", endpoint, str_query])
-    println("Message: ", message) 
     query.signature = hexdigest("sha256", client.secret_key, message)
     return query
 end

--- a/src/Coinbase/Coinbase.jl
+++ b/src/Coinbase/Coinbase.jl
@@ -72,10 +72,10 @@ function CryptoAPIs.request_sign!(::CoinbaseClient, query::Q, ::String)::Q where
     return query
 end
 
-function CryptoAPIs.request_sign!(client::CoinbaseClient, query::Q, ::String)::Q where {Q<:CoinbasePrivateQuery}
+function CryptoAPIs.request_sign!(client::CoinbaseClient, query::Q, endpoint::String)::Q where {Q<:CoinbasePrivateQuery}
     query.timestamp = string(round(Int64, datetime2unix(Dates.now(UTC))))
     query.signature = nothing
-    message = join([query.timestamp, method, endpoint, query])
+    message = join([query.timestamp, "GET", endpoint, query])
     query.signature = hexdigest("sha256", client.secret_key, message)
     return query
 end

--- a/src/Coinbase/Coinbase.jl
+++ b/src/Coinbase/Coinbase.jl
@@ -75,7 +75,7 @@ end
 function CryptoAPIs.request_sign!(client::CoinbaseClient, query::Q, endpoint::String)::Q where {Q<:CoinbasePrivateQuery}
     query.timestamp = string(round(Int64, datetime2unix(Dates.now(UTC))))
     query.signature = nothing
-    message = join([query.timestamp, "GET", endpoint, query])
+    message = join([query.timestamp, "GET", endpoint])
     query.signature = hexdigest("sha256", client.secret_key, message)
     return query
 end

--- a/src/Coinbase/Coinbase.jl
+++ b/src/Coinbase/Coinbase.jl
@@ -72,6 +72,14 @@ function CryptoAPIs.request_sign!(::CoinbaseClient, query::Q, ::String)::Q where
     return query
 end
 
+function CryptoAPIs.request_sign!(client::CoinbaseClient, query::Q, ::String)::Q where {Q<:CoinbasePrivateQuery}
+    query.timestamp = Dates.now(UTC)
+    query.signature = nothing
+    str_query = Serde.to_query(query)
+    query.signature = hexdigest("sha256", client.secret_key, str_query)
+    return query
+end
+
 function CryptoAPIs.request_body(::Q)::String where {Q<:CoinbaseCommonQuery}
     return ""
 end
@@ -84,6 +92,13 @@ function CryptoAPIs.request_headers(client::CoinbaseClient, ::CoinbaseCommonQuer
     return Pair{String,String}[
         "Content-Type" => "application/json",
         "User-Agent" => "CryptoAPIs.Coinbase",
+    ]
+end
+
+function CryptoAPIs.request_headers(client::CoinbaseClient, ::CoinbasePrivateQuery)::Vector{Pair{String,String}}
+    return Pair{String,String}[
+        "Content-Type" => "application/json",
+        "CB-ACCESS-KEY" => client.public_key,
     ]
 end
 

--- a/src/Coinbase/Coinbase.jl
+++ b/src/Coinbase/Coinbase.jl
@@ -76,7 +76,9 @@ function CryptoAPIs.request_sign!(client::CoinbaseClient, query::Q, endpoint::St
     query.timestamp = string(round(Int64, datetime2unix(Dates.now(UTC))))
     query.signature = nothing
     str_query = Serde.to_query(query)
+    endpoint = "/" * endpoint * "?"
     message = join([query.timestamp, "GET", endpoint, str_query])
+    println("Message: ", message) 
     query.signature = hexdigest("sha256", client.secret_key, message)
     return query
 end

--- a/src/Coinbase/Errors.jl
+++ b/src/Coinbase/Errors.jl
@@ -5,6 +5,9 @@ import ..CryptoAPIs: APIsResult, APIsUndefError, isretriable, retry_maxcount, re
 # UNHANDLED
 isretriable(::APIsResult{CoinbaseAPIError}) = true
 
+# Invalid Passphrase
+isretriable(e::APIsResult{CoinbaseAPIError{Symbol("Invalid Passphrase")}}) = false
+
 # Invalid Price
 isretriable(e::APIsResult{CoinbaseAPIError{Symbol("Invalid Price")}}) = false
 

--- a/src/Coinbase/Spot/API/FeeEstimate.jl
+++ b/src/Coinbase/Spot/API/FeeEstimate.jl
@@ -10,10 +10,13 @@ using Dates, NanoDates, TimeZones
 using CryptoAPIs.Coinbase
 using CryptoAPIs: Maybe, APIsRequest
 
-Base.@kwdef struct FeeEstimateQuery <: CoinbasePublicQuery
+Base.@kwdef struct FeeEstimateQuery <: CoinbasePrivateQuery
     currency::Maybe{String} = nothing
     crypto_address::Maybe{String} = nothing
     network::Maybe{String} = nothing
+
+    timestamp::Maybe{DateTime} = nothing
+    signature::Maybe{String} = nothing
 end
 
 struct FeeEstimateData <: CoinbaseData
@@ -23,7 +26,7 @@ end
 
 """
     fee_estimate(client::CoinbaseClient, query::FeeEstimateQuery)
-    fee_estimate(client::CoinbaseClient = Coinbase.Spot.public_client; kw...)
+    fee_estimate(client::CoinbaseClient; kw...)
 
 Gets the fee estimate for the crypto withdrawal to crypto address.
 
@@ -36,6 +39,8 @@ Gets the fee estimate for the crypto withdrawal to crypto address.
 | currency       | String       | false    |             |
 | crypto_address | String       | false    |             |
 | network        | String       | false    |             |
+| signature      | String       | false    |             |
+| timestamp      | DateTime     | false    |             |
 
 ## Code samples:
 
@@ -43,7 +48,13 @@ Gets the fee estimate for the crypto withdrawal to crypto address.
 using Serde
 using CryptoAPIs.Coinbase
 
-result = Coinbase.Spot.fee_estimate()
+coinbase_client = CoinbaseClient(;
+    base_url = "https://api.exchange.coinbase.com",
+    public_key = ENV["COINBASE_PUBLIC_KEY"],
+    secret_key = ENV["COINBASE_SECRET_KEY"],
+)
+
+result = Coinbase.Spot.fee_estimate(coinbase_client)
 
 to_pretty_json(result.result)
 ```

--- a/src/Coinbase/Spot/API/FeeEstimate.jl
+++ b/src/Coinbase/Spot/API/FeeEstimate.jl
@@ -10,12 +10,12 @@ using Dates, NanoDates, TimeZones
 using CryptoAPIs.Coinbase
 using CryptoAPIs: Maybe, APIsRequest
 
-Base.@kwdef struct FeeEstimateQuery <: CoinbasePrivateQuery
+Base.@kwdef mutable struct FeeEstimateQuery <: CoinbasePrivateQuery
     currency::Maybe{String} = nothing
     crypto_address::Maybe{String} = nothing
     network::Maybe{String} = nothing
 
-    timestamp::Maybe{DateTime} = nothing
+    timestamp::Maybe{String} = nothing
     signature::Maybe{String} = nothing
 end
 

--- a/src/Coinbase/Spot/API/FeeEstimate.jl
+++ b/src/Coinbase/Spot/API/FeeEstimate.jl
@@ -1,0 +1,62 @@
+module FeeEstimate
+
+export FeeEstimateQuery,
+    FeeEstimateData,
+    fee_estimate
+
+using Serde
+using Dates, NanoDates, TimeZones
+
+using CryptoAPIs.Coinbase
+using CryptoAPIs: Maybe, APIsRequest
+
+Base.@kwdef struct FeeEstimateQuery <: CoinbasePublicQuery
+    currency::Maybe{String} = nothing
+    crypto_address::Maybe{String} = nothing
+    network::Maybe{String} = nothing
+end
+
+struct FeeEstimateData <: CoinbaseData
+    fee::Maybe{String}
+    fee_before_subsidy::Maybe{String}
+end
+
+"""
+    fee_estimate(client::CoinbaseClient, query::FeeEstimateQuery)
+    fee_estimate(client::CoinbaseClient = Coinbase.Spot.public_client; kw...)
+
+Gets the fee estimate for the crypto withdrawal to crypto address.
+
+[`GET withdrawals/fee-estimate`](https://docs.cloud.coinbase.com/exchange/reference/exchangerestapi_getwithdrawfeeestimate)
+
+## Parameters:
+
+| Parameter      | Type         | Required | Description |
+|:---------------|:-------------|:---------|:------------|
+| currency       | String       | false    |             |
+| crypto_address | String       | false    |             |
+| network        | String       | false    |             |
+
+## Code samples:
+
+```julia
+using Serde
+using CryptoAPIs.Coinbase
+
+result = Coinbase.Spot.fee_estimate()
+
+to_pretty_json(result.result)
+```
+
+## Result:
+
+"""
+function fee_estimate(client::CoinbaseClient, query::FeeEstimateQuery)
+    return APIsRequest{FeeEstimateData}("GET", "withdrawals/fee-estimate", query)(client)
+end
+
+function fee_estimate(client::CoinbaseClient = Coinbase.Spot.public_client; kw...)
+    return fee_estimate(client, FeeEstimateQuery(; kw...))
+end
+
+end

--- a/src/Coinbase/Spot/API/FeeEstimate.jl
+++ b/src/Coinbase/Spot/API/FeeEstimate.jl
@@ -20,8 +20,8 @@ Base.@kwdef mutable struct FeeEstimateQuery <: CoinbasePrivateQuery
 end
 
 struct FeeEstimateData <: CoinbaseData
-    fee::Maybe{String}
-    fee_before_subsidy::Maybe{String}
+    fee::Maybe{Float64}
+    fee_before_subsidy::Maybe{Float64}
 end
 
 """
@@ -40,7 +40,7 @@ Gets the fee estimate for the crypto withdrawal to crypto address.
 | crypto_address | String       | false    |             |
 | network        | String       | false    |             |
 | signature      | String       | false    |             |
-| timestamp      | DateTime     | false    |             |
+| timestamp      | String       | false    |             |
 
 ## Code samples:
 
@@ -62,6 +62,12 @@ to_pretty_json(result.result)
 
 ## Result:
 
+```json
+{
+  "fee":0.1,
+  "fee_before_subsidy":0.01
+}
+```
 """
 function fee_estimate(client::CoinbaseClient, query::FeeEstimateQuery)
     return APIsRequest{FeeEstimateData}("GET", "withdrawals/fee-estimate", query)(client)

--- a/src/Coinbase/Spot/API/FeeEstimate.jl
+++ b/src/Coinbase/Spot/API/FeeEstimate.jl
@@ -52,6 +52,7 @@ coinbase_client = CoinbaseClient(;
     base_url = "https://api.exchange.coinbase.com",
     public_key = ENV["COINBASE_PUBLIC_KEY"],
     secret_key = ENV["COINBASE_SECRET_KEY"],
+    passphrase = ENV["COINBASE_PASSPHRASE"],
 )
 
 result = Coinbase.Spot.fee_estimate(coinbase_client)

--- a/src/Coinbase/Spot/API/FeeEstimate.jl
+++ b/src/Coinbase/Spot/API/FeeEstimate.jl
@@ -66,7 +66,7 @@ function fee_estimate(client::CoinbaseClient, query::FeeEstimateQuery)
     return APIsRequest{FeeEstimateData}("GET", "withdrawals/fee-estimate", query)(client)
 end
 
-function fee_estimate(client::CoinbaseClient = Coinbase.Spot.public_client; kw...)
+function fee_estimate(client::CoinbaseClient; kw...)
     return fee_estimate(client, FeeEstimateQuery(; kw...))
 end
 

--- a/src/Coinbase/Spot/API/ProductStats.jl
+++ b/src/Coinbase/Spot/API/ProductStats.jl
@@ -1,0 +1,83 @@
+module ProductStats
+
+export ProductStatsQuery,
+    ProductStatsData,
+    product_stats
+
+using Serde
+using Dates, NanoDates, TimeZones
+
+using CryptoAPIs.Coinbase
+using CryptoAPIs: Maybe, APIsRequest
+
+Base.@kwdef struct ProductStatsQuery <: CoinbasePublicQuery
+    #__ empty
+end
+
+struct ProductStatsData <: CoinbaseData
+    open::Float64
+    high::Float64
+    low::Float64
+    last::Float64
+    volume::Float64
+    volume_30day::Maybe{Float64}
+    rfq_volume_24hour::Maybe{Float64}
+    rfq_volume_30day::Maybe{Float64}
+    conversions_volume_24hour::Maybe{Float64}
+    conversions_volume_30day::Maybe{Float64}
+end
+
+"""
+    product_stats(client::CoinbaseClient, query::ProductStatsQuery)
+    product_stats(client::CoinbaseClient = Coinbase.Spot.public_client; kw...)
+
+Get rates for a single product by product ID, grouped in buckets.
+
+[`GET products/{product_id}/stats`](https://docs.cloud.coinbase.com/exchange/reference/exchangerestapi_getproductstats)
+
+## Parameters:
+
+| Parameter   | Type         | Required | Description |
+|:------------|:-------------|:---------|:------------|
+| granularity | TimeInterval | true     |             |
+| start       | DateTime     | false    |             |
+| _end        | DateTime     | false    |             |
+
+
+## Code samples:
+
+```julia
+using Serde
+using CryptoAPIs.Coinbase
+
+result = Coinbase.Spot.product_stats()
+
+to_pretty_json(result.result)
+```
+
+## Result:
+
+```json
+{
+  "open":65837.77,
+  "high":66944.06,
+  "low":64500.0,
+  "last":65975.28,
+  "volume":15431.78734886,
+  "volume_30day":648921.33864485,
+  "rfq_volume_24hour":20.273182,
+  "rfq_volume_30day":1452.764429,
+  "conversions_volume_24hour":null,
+  "conversions_volume_30day":null
+}
+```
+"""
+function product_stats(client::CoinbaseClient, query::ProductStatsQuery; product_id::String)
+    return APIsRequest{ProductStatsData}("GET", "products/$product_id/stats", query)(client)
+end
+
+function product_stats(client::CoinbaseClient = Coinbase.Spot.public_client; product_id::String, kw...)
+    return product_stats(client, ProductStatsQuery(; kw...); product_id = product_id)
+end
+
+end

--- a/src/Coinbase/Spot/API/ProductStats.jl
+++ b/src/Coinbase/Spot/API/ProductStats.jl
@@ -35,15 +35,6 @@ Get rates for a single product by product ID, grouped in buckets.
 
 [`GET products/{product_id}/stats`](https://docs.cloud.coinbase.com/exchange/reference/exchangerestapi_getproductstats)
 
-## Parameters:
-
-| Parameter   | Type         | Required | Description |
-|:------------|:-------------|:---------|:------------|
-| granularity | TimeInterval | true     |             |
-| start       | DateTime     | false    |             |
-| _end        | DateTime     | false    |             |
-
-
 ## Code samples:
 
 ```julia

--- a/src/Coinbase/Spot/Spot.jl
+++ b/src/Coinbase/Spot/Spot.jl
@@ -14,10 +14,16 @@ using .Candle
 include("API/Currency.jl")
 using .Currency
 
-include("API/Ticker.jl")
-using .Ticker
+include("API/FeeEstimate.jl")
+using .FeeEstimate
 
 include("API/Product.jl")
 using .Product
+
+include("API/ProductStats.jl")
+using .ProductStats
+
+include("API/Ticker.jl")
+using .Ticker
 
 end

--- a/src/Coinbase/Utils.jl
+++ b/src/Coinbase/Utils.jl
@@ -5,7 +5,7 @@ function Serde.deser(::Type{<:CoinbaseData}, ::Type{<:NanoDate}, x::AbstractStri
 end
 
 function Serde.deser(::Type{<:CoinbaseData}, ::Type{<:NanoDate}, x::Int64)::NanoDate
-    return unixnanos2nanodate(x*1e9)
+    return unixnanos2nanodate(x * 1e9)
 end
 
 function Serde.ser_ignore_field(::Type{<:CoinbaseCommonQuery}, ::Val{:timestamp})::Bool

--- a/src/Coinbase/Utils.jl
+++ b/src/Coinbase/Utils.jl
@@ -8,6 +8,10 @@ function Serde.deser(::Type{<:CoinbaseData}, ::Type{<:NanoDate}, x::Int64)::Nano
     return unixnanos2nanodate(x*1e9)
 end
 
+function Serde.ser_ignore_field(::Type{<:CoinbaseCommonQuery}, ::Val{:timestamp})::Bool
+    return true
+end
+
 function Serde.SerQuery.ser_name(::Type{<:CoinbaseCommonQuery}, ::Val{:_end})::String
     return "end"
 end

--- a/src/Coinbase/Utils.jl
+++ b/src/Coinbase/Utils.jl
@@ -12,6 +12,10 @@ function Serde.ser_ignore_field(::Type{<:CoinbaseCommonQuery}, ::Val{:timestamp}
     return true
 end
 
+function Serde.ser_ignore_field(::Type{<:CoinbaseCommonQuery}, ::Val{:signature})::Bool
+    return true
+end
+
 function Serde.SerQuery.ser_name(::Type{<:CoinbaseCommonQuery}, ::Val{:_end})::String
     return "end"
 end

--- a/src/Coinbase/Utils.jl
+++ b/src/Coinbase/Utils.jl
@@ -16,6 +16,10 @@ function Serde.ser_ignore_field(::Type{<:CoinbaseCommonQuery}, ::Val{:signature}
     return true
 end
 
+function Serde.ser_ignore_field(::Type{<:CoinbaseCommonQuery}, ::Val{:timestamp})::Bool
+    return true
+end
+
 function Serde.SerQuery.ser_name(::Type{<:CoinbaseCommonQuery}, ::Val{:_end})::String
     return "end"
 end

--- a/src/Coinbase/Utils.jl
+++ b/src/Coinbase/Utils.jl
@@ -20,6 +20,10 @@ function Serde.ser_ignore_field(::Type{<:CoinbaseCommonQuery}, ::Val{:timestamp}
     return true
 end
 
+function Serde.ser_ignore_field(::Type{<:CoinbaseCommonQuery}, ::Val{:signature})::Bool
+    return true
+end
+
 function Serde.SerQuery.ser_name(::Type{<:CoinbaseCommonQuery}, ::Val{:_end})::String
     return "end"
 end

--- a/src/Coinbase/Utils.jl
+++ b/src/Coinbase/Utils.jl
@@ -16,14 +16,6 @@ function Serde.ser_ignore_field(::Type{<:CoinbaseCommonQuery}, ::Val{:signature}
     return true
 end
 
-function Serde.ser_ignore_field(::Type{<:CoinbaseCommonQuery}, ::Val{:timestamp})::Bool
-    return true
-end
-
-function Serde.ser_ignore_field(::Type{<:CoinbaseCommonQuery}, ::Val{:signature})::Bool
-    return true
-end
-
 function Serde.SerQuery.ser_name(::Type{<:CoinbaseCommonQuery}, ::Val{:_end})::String
     return "end"
 end


### PR DESCRIPTION
Pull request contains new modules for Coinbase Spot API such as FeeEstimate and ProductStats specified in https://github.com/bhftbootcamp/CryptoAPIs.jl/issues/4

The following issue will be resolved with this PR:

closes https://github.com/bhftbootcamp/CryptoAPIs.jl/issues/4 Extend Coinbase Spot API support

### Pull request checklist

- [x] Did you bump the project version?
- [x] Did you add a description to the Pull Request?
- [ ] Did you add new tests?
- [ ] Did you add reviewers?
